### PR TITLE
Add versioning handling for react.

### DIFF
--- a/react.config.json
+++ b/react.config.json
@@ -1,0 +1,42 @@
+{
+    "en": {
+        "development": {
+            "url": "https://dev.infragistics.com",
+            "gaID": "GTM-WLXLBZD",
+            "versions": "https://staging.infragistics.com/react-docs/react-api-docs-versions.json",
+            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-react/api/docs/typescript/latest/"
+        },
+        "staging": {
+            "url": "https://staging.infragistics.com",
+            "gaID": "GTM-NCKNPN",
+            "versions": "https://staging.infragistics.com/react-docs/react-api-docs-versions.json",
+            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-react/api/docs/typescript/latest/"
+        },
+        "production": {
+            "url": "https://www.infragistics.com",
+            "gaID": "GTM-T65CF7",
+            "versions": "https://www.infragistics.com/react-docs/react-api-docs-versions-prod.json",
+            "typedoc_default_url": "https://www.infragistics.com/products/ignite-ui-react/api/docs/typescript/latest/"
+        }
+    },
+    "jp": {
+        "development": {
+            "url": "https://jp.dev.infragistics.com",
+            "gaID": "GTM-NNHVMC7",
+            "versions": "https://jp.staging.infragistics.com/react-docs/react-api-docs-versions-jp.json",
+            "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-react/api/docs/typescript/latest/"
+        },
+        "staging": {
+            "url": "https://jp.staging.infragistics.com",
+            "gaID": "GTM-WLWSDK",
+            "versions": "https://jp.staging.infragistics.com/react-docs/react-api-docs-versions-jp.json",
+            "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-react/api/docs/typescript/latest/"
+        },
+        "production": {
+            "url": "https://jp.infragistics.com",
+            "gaID": "GTM-KVNSWJ",
+            "versions": "https://jp.infragistics.com/react-docs/react-api-docs-versions-prod-jp.json",
+            "typedoc_default_url": "https://jp.infragistics.com/products/ignite-ui-react/api/docs/typescript/latest/"
+        }
+    }
+}

--- a/src/assets/js/src/versioning/tag-versions.req.js
+++ b/src/assets/js/src/versioning/tag-versions.req.js
@@ -1,7 +1,6 @@
 (function () {
-    let baseUrl = $('body').data('base-url');
     const versionsJson = $('body').data('api-versions-json');
-
+    const defaultUrl = $('body').data('default-url');
     $.ajax({
         url: versionsJson,
         type: "get",
@@ -14,20 +13,19 @@
         const select = $('#versions');
 
         folders = folders.reverse();
-
-        baseUrl += "/products/ignite-ui-angular/docs/";
         folders.forEach(function (f) {
+            const versionUrl = defaultUrl.replace("typescript/latest'", f + "/typescript")
             select.append($('<option>', {
-                value: baseUrl + f + "/typescript",
+                value: versionUrl,
                 text: f
             }));
         });
 
         const version = folders.filter(function(v){ return window.location.href.indexOf(v) >= 0;})[0];
         if (version) {
-            select.val(baseUrl + version + "/typescript");
+            select.val(versionUrl);
         } else {
-            select.val(baseUrl + folders[0] + "/typescript");
+            select.val(versionUrl);
         }
     });
 

--- a/src/layouts/default.tsx
+++ b/src/layouts/default.tsx
@@ -12,6 +12,7 @@ export const defaultLayout = (context: DefaultThemeRenderContext, props: PageEve
     const baseUrl = getConfigData(context, 'url');
     const apiJsonFile = getConfigData(context, 'versions');
     const searchPath = getConfigData(context, 'assets/js/search.json');
+    const defaultUrl =  getConfigData(context, 'typedoc_default_url')
     const gaID = getConfigData(context, 'gaID');
     return (
         <html class="default no-js" lang="en">
@@ -51,7 +52,7 @@ export const defaultLayout = (context: DefaultThemeRenderContext, props: PageEve
                 {analytics(context)}
                 {context.hook("head.end")}
             </head>
-            <body id="body" data-base-url={baseUrl} data-api-versions-json={apiJsonFile}>
+            <body id="body" data-base-url={baseUrl} data-api-versions-json={apiJsonFile} default-url={defaultUrl}>
                 {context.hook('body.begin')}
                 {/* Google Tag Manager (noscript) */}
                 <noscript>

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -94,7 +94,10 @@ export function stringify(data: unknown) {
 }
 
 export function getConfigData(context: DefaultThemeRenderContext, prop: string, lang?: string): string {
-    const fileName = 'config.json';
+    const product = context.options.getValue('product') as string;
+    const prodArr = product.split('-')
+    const prodName = prodArr[prodArr.length - 1];
+    const fileName = prodName == 'angular' ? 'config.json' : prodName + '.config.json';
 
     const normalizedPath = path.join(__dirname, '..' , fileName);
     const config = JSON.parse(fs.readFileSync(normalizedPath, 'utf8'));

--- a/src/utils/lib.tsx
+++ b/src/utils/lib.tsx
@@ -98,9 +98,9 @@ export function getConfigData(context: DefaultThemeRenderContext, prop: string, 
     const prodArr = product.split('-')
     const prodName = prodArr[prodArr.length - 1];
     const fileName = prodName == 'angular' ? 'config.json' : prodName + '.config.json';
+    const filePath = getConfigFilePath(fileName);
 
-    const normalizedPath = path.join(__dirname, '..' , fileName);
-    const config = JSON.parse(fs.readFileSync(normalizedPath, 'utf8'));
+    const config = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     const settingOpt =  context.options.getValue('localize') as string;
     const getLang = lang ? lang : settingOpt;
 
@@ -111,4 +111,14 @@ export function getConfigData(context: DefaultThemeRenderContext, prop: string, 
 
     const res = data ? data[prop] : '';
     return res;
+}
+
+export function getConfigFilePath(fileName: string) : string {
+    const normalizedPath = path.join(__dirname, '..' , fileName);
+    if (fs.existsSync(normalizedPath)) {
+        return normalizedPath;
+    } else {
+        // fallback to default config
+        return path.join(__dirname, '..' , 'config.json');
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,7 +79,7 @@ const config = {
             patterns: [
                 {
                     context: path.resolve(__dirname),
-                    from: "config.json",
+                    from: "*config.json",
                     to: path.resolve(__dirname, "dist"),
                 },
             ],


### PR DESCRIPTION
Related to https://github.com/IgniteUI/igniteui-xplat-docs/issues/1043

Make code a bit more platform agnostic and add a config for reacts urls, so that once the older versions folders and version lists json are deployed the version drop-down can get them from the correct paths.


Note: This depends on the new props exposed here: https://github.com/IgniteUI/typedoc-plugin-localization/pull/70/