### PR TITLE
fix(wc): Fix wc urls to point to latest.

### DIFF
--- a/webcomponents.dockmanager.config.json
+++ b/webcomponents.dockmanager.config.json
@@ -4,19 +4,19 @@
             "url": "https://dev.infragistics.local",
             "gaID": "GTM-WLXLBZD",
             "versions": "https://staging.infragistics.local/dock-manager/docs/webcomponents-api-docs-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.local/products/dock-manager/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.local/products/dock-manager/docs/typescript/latest/"
         },
         "staging": {
             "url": "https://staging.infragistics.local",
             "gaID": "GTM-NCKNPN",
             "versions": "https://staging.infragistics.local/dock-manager/docs/webcomponents-api-docs-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.local/products/dock-manager/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.local/products/dock-manager/docs/typescript/latest/"
         },
         "production": {
             "url": "https://www.infragistics.com",
             "gaID": "GTM-T65CF7",
             "versions": "https://www.infragistics.com/dock-manager/docs/webcomponents-api-docs-versions-prod.json",
-            "typedoc_default_url": "https://www.infragistics.com/products/dock-manager/docs/typescript/"
+            "typedoc_default_url": "https://www.infragistics.com/products/dock-manager/docs/typescript/latest/"
         }
     },
     "jp": {
@@ -24,19 +24,19 @@
             "url": "https://jp.dev.infragistics.local",
             "gaID": "GTM-NNHVMC7",
             "versions": "https://jp.staging.infragistics.local/dock-manager/docs/webcomponents-api-docs-versions-jp.json",
-            "typedoc_default_url": "https://jp.staging.infragistics.local/products/dock-manager/docs/typescript/"
+            "typedoc_default_url": "https://jp.staging.infragistics.local/products/dock-manager/docs/typescript/latest/"
         },
         "staging": {
             "url": "https://jp.staging.infragistics.local",
             "gaID": "GTM-WLWSDK",
             "versions": "https://jp.staging.infragistics.local/dock-manager/docs/webcomponents-api-docs-versions-jp.json",
-            "typedoc_default_url": "https://jp.staging.infragistics.local/products/dock-manager/docs/typescript/"
+            "typedoc_default_url": "https://jp.staging.infragistics.local/products/dock-manager/docs/typescript/latest/"
         },
         "production": {
             "url": "https://jp.infragistics.com",
             "gaID": "GTM-KVNSWJ",
             "versions": "https://jp.infragistics.com/dock-manager/docs/webcomponents-api-docs-versions-prod-jp.json",
-            "typedoc_default_url": "https://jp.infragistics.com/products/dock-manager/docs/typescript/"
+            "typedoc_default_url": "https://jp.infragistics.com/products/dock-manager/docs/typescript/latest/"
         }
     }
 }

--- a/webcomponents.grids.config.json
+++ b/webcomponents.grids.config.json
@@ -4,19 +4,19 @@
             "url": "https://dev.infragistics.local",
             "gaID": "GTM-WLXLBZD",
             "versions": "https://staging.infragistics.com/products/ignite-ui-web-components-grids/docs/webcomponents-grids-apis-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/latest/"
         },
         "staging": {
             "url": "https://staging.infragistics.com",
             "gaID": "GTM-NCKNPN",
             "versions": "https://staging.infragistics.com/products/ignite-ui-web-components-grids/docs/webcomponents-grids-apis-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/latest/"
         },
         "production": {
             "url": "https://www.infragistics.com",
             "gaID": "GTM-T65CF7",
             "versions": "https://www.infragistics.com/products/ignite-ui-web-components-grids/docs/webcomponents-grids-apis-versions.json",
-            "typedoc_default_url": "https://www.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/"
+            "typedoc_default_url": "https://www.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/latest/"
         }
     },
     "jp": {
@@ -24,19 +24,19 @@
             "url": "https://jp.dev.infragistics.local",
             "gaID": "GTM-NNHVMC7",
             "versions": "https://jp.staging.infragistics.com/products/ignite-ui-web-components-grids/docs/webcomponents-grids-apis-versions.json",
-            "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/"
+            "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/latest/"
         },
         "staging": {
             "url": "https://jp.staging.infragistics.com",
             "gaID": "GTM-WLWSDK",
             "versions": "https://jp.staging.infragistics.com/products/ignite-ui-web-components-grids/docs/webcomponents-grids-apis-versions.json",
-            "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/"
+            "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/latest/"
         },
         "production": {
             "url": "https://jp.infragistics.com",
             "gaID": "GTM-KVNSWJ",
             "versions": "https://jp.infragistics.com/products/ignite-ui-web-components-grids/docs/webcomponents-grids-apis-versions.json",
-            "typedoc_default_url": "https://jp.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/"
+            "typedoc_default_url": "https://jp.infragistics.com/products/ignite-ui-web-components-grids/docs/typescript/latest/"
         }
     }
 }

--- a/webcomponents.licensed.config.json
+++ b/webcomponents.licensed.config.json
@@ -4,19 +4,19 @@
             "url": "https://dev.infragistics.com",
             "gaID": "GTM-WLXLBZD",
             "versions": "https://staging.infragistics.com/products/ignite-ui-web-components/api/docs/webcomponents-api-docs-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/latest/"
         },
         "staging": {
             "url": "https://staging.infragistics.com",
             "gaID": "GTM-NCKNPN",
             "versions": "https://staging.infragistics.com/products/ignite-ui-web-components/api/docs/webcomponents-api-docs-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/latest/"
         },
         "production": {
             "url": "https://www.infragistics.com",
             "gaID": "GTM-T65CF7",
             "versions": "https://www.infragistics.com/products/ignite-ui-web-components/api/docs/webcomponents-api-docs-versions-prod.json",
-            "typedoc_default_url": "https://www.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/"
+            "typedoc_default_url": "https://www.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/latest/"
         }
     },
     "jp": {
@@ -24,19 +24,19 @@
             "url": "https://jp.dev.infragistics.com",
             "gaID": "GTM-NNHVMC7",
             "versions": "https://jp.staging.infragistics.local/ignite-ui-web-components/api/docs/webcomponents-api-docs-versions-jp.json",
-            "typedoc_default_url": "https://jp.staging.infragistics.local/products/ignite-ui-web-components/api/docs/typescript/"
+            "typedoc_default_url": "https://jp.staging.infragistics.local/products/ignite-ui-web-components/api/docs/typescript/latest/"
         },
       "staging": {
         "url": "https://jp.staging.infragistics.com",
         "gaID": "GTM-WLWSDK",
         "versions": "https://jp.staging.infragistics.com/products/ignite-ui-web-components/api/docs/webcomponents-api-docs-versions-jp.json",
-        "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/"
+        "typedoc_default_url": "https://jp.staging.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/latest/"
       },
       "production": {
         "url": "https://jp.infragistics.com",
         "gaID": "GTM-KVNSWJ",
         "versions": "https://jp.infragistics.com/products/ignite-ui-web-components/api/docs/webcomponents-api-docs-versions-prod-jp.json",
-        "typedoc_default_url": "https://jp.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/"
+        "typedoc_default_url": "https://jp.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/latest/"
       }
     }
 }

--- a/webcomponents.oss.config.json
+++ b/webcomponents.oss.config.json
@@ -4,19 +4,19 @@
             "url": "https://dev.infragistics.local",
             "gaID": "GTM-WLXLBZD",
             "versions": "https://staging.infragistics.local/ignite-ui-web-components/docs/webcomponents-api-docs-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/latest/"
         },
         "staging": {
             "url": "https://staging.infragistics.local",
             "gaID": "GTM-NCKNPN",
             "versions": "https://staging.infragistics.local/ignite-ui-web-components/docs/webcomponents-api-docs-versions.json",
-            "typedoc_default_url": "https://staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/"
+            "typedoc_default_url": "https://staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/latest/"
         },
         "production": {
             "url": "https://www.infragistics.com",
             "gaID": "GTM-T65CF7",
             "versions": "https://www.infragistics.com/ignite-ui-web-components/docs/webcomponents-api-docs-versions-prod.json",
-            "typedoc_default_url": "https://www.infragistics.com/products/ignite-ui-web-components/docs/typescript/"
+            "typedoc_default_url": "https://www.infragistics.com/products/ignite-ui-web-components/docs/typescript/latest/"
         }
     },
     "jp": {
@@ -24,19 +24,19 @@
             "url": "https://jp.dev.infragistics.local",
             "gaID": "GTM-NNHVMC7",
             "versions": "https://jp.staging.infragistics.local/ignite-ui-web-components/docs/webcomponents-api-docs-versions-jp.json",
-            "typedoc_default_url": "https://jp.staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/"
+            "typedoc_default_url": "https://jp.staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/latest/"
         },
         "staging": {
             "url": "https://jp.staging.infragistics.local",
             "gaID": "GTM-WLWSDK",
             "versions": "https://jp.staging.infragistics.local/ignite-ui-web-components/docs/webcomponents-api-docs-versions-jp.json",
-            "typedoc_default_url": "https://jp.staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/"
+            "typedoc_default_url": "https://jp.staging.infragistics.local/products/ignite-ui-web-components/docs/typescript/latest/"
         },
         "production": {
             "url": "https://jp.infragistics.com",
             "gaID": "GTM-KVNSWJ",
             "versions": "https://jp.infragistics.com/ignite-ui-web-components/docs/webcomponents-api-docs-versions-prod-jp.json",
-            "typedoc_default_url": "https://jp.infragistics.com/products/ignite-ui-web-components/docs/typescript/"
+            "typedoc_default_url": "https://jp.infragistics.com/products/ignite-ui-web-components/docs/typescript/latest/"
         }
     }
 }


### PR DESCRIPTION
Seems that the versioning drop-down expects urls to be in format "typescript/latest" in order to replace the correct version number:
https://github.com/IgniteUI/ig-typedoc-theme/blob/master/src/assets/js/src/versioning/tag-versions.req.js#L17

Hence why it fails on live ATM and you cannot change the version via the drop-down, even though everything is deployed and available: 
https://www.infragistics.com/products/ignite-ui-web-components/api/docs/typescript/latest/

Once merged we'll need a new version with the change to update the pipelines.